### PR TITLE
Fixed a bug introduced by iOS file handler limit of 250 [Issue #7]

### DIFF
--- a/lib/util/communication_handler.dart
+++ b/lib/util/communication_handler.dart
@@ -58,17 +58,18 @@ class CommunicationHandler {
         // print("Searching on subnet $subnet...");
 
         // TODO: Maybe display the progress as some sort of bar or whatever
-        final mirrorHostStream = HostScanner.discoverPort(subnet, _port);
+        final mirrorHostStream =
+            HostScanner.scanDevicesForSinglePort(subnet, _port);
 
         await for (ActiveHost mirrorHost in mirrorHostStream) {
           final devicePort = mirrorHost.openPort[0];
 
           if (devicePort.isOpen) {
-            bool isMirror = await isMagicMirror(mirrorHost.ip);
+            bool isMirror = await isMagicMirror(mirrorHost.address);
 
             if (isMirror) {
               // print("This is indeed a mirror!");
-              mirrorList.add(mirrorHost.ip);
+              mirrorList.add(mirrorHost.address);
             }
           }
         }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -258,7 +258,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.5"
   http_parser:
     dependency: transitive
     description:
@@ -307,7 +307,7 @@ packages:
       name: lint
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.10.0"
   lints:
     dependency: transitive
     description:
@@ -396,11 +396,11 @@ packages:
     dependency: "direct main"
     description:
       path: network_tools
-      ref: HEAD
-      resolved-ref: "091c8b9d1d9f1f98d4d39748731806c9e3499b51"
+      ref: merged
+      resolved-ref: "5dd7b033daff478514ec4e148c9a5c16f15e6771"
       url: "https://github.com/Stausssi/network_tools"
     source: git
-    version: "2.1.0"
+    version: "3.0.0"
   nm:
     dependency: transitive
     description:
@@ -435,7 +435,7 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -395,9 +395,11 @@ packages:
   network_tools:
     dependency: "direct main"
     description:
-      name: network_tools
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: network_tools
+      ref: HEAD
+      resolved-ref: "091c8b9d1d9f1f98d4d39748731806c9e3499b51"
+      url: "https://github.com/Stausssi/network_tools"
+    source: git
     version: "2.1.0"
   nm:
     dependency: transitive

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -395,12 +395,10 @@ packages:
   network_tools:
     dependency: "direct main"
     description:
-      path: network_tools
-      ref: merged
-      resolved-ref: "5dd7b033daff478514ec4e148c9a5c16f15e6771"
-      url: "https://github.com/Stausssi/network_tools"
-    source: git
-    version: "3.0.0"
+      name: network_tools
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0+2"
   nm:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependency_overrides:
     git:
       url: https://github.com/Stausssi/network_tools
       path: network_tools
+      ref: merged
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,14 +41,14 @@ dependencies:
   settings_ui: ^2.0.2
   shared_preferences: ^2.0.15
   flutter_colorpicker: ^1.0.3
-  http: ^0.13.4
+  http: ^0.13.5
   network_info_plus: ^2.1.3
-  network_tools: ^2.1.0
+  network_tools: ^3.0.0+2
   flutter_native_splash: ^2.2.7
   convex_bottom_bar: ^3.0.0
   introduction_screen: ^3.0.2
   pull_to_refresh: ^2.0.0
-  google_mlkit_face_detection: ^0.3.0
+  google_mlkit_face_detection: ^0.4.0
   camera: ^0.10.0
   image: ^3.2.0
   dart_ping_ios: ^2.0.0
@@ -58,12 +58,6 @@ dependency_overrides:
   pull_to_refresh:
     git:
       url: https://github.com/miquelbeltran/flutter_pulltorefresh
-
-  network_tools:
-    git:
-      url: https://github.com/Stausssi/network_tools
-      path: network_tools
-      ref: merged
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,11 @@ dependency_overrides:
     git:
       url: https://github.com/miquelbeltran/flutter_pulltorefresh
 
+  network_tools:
+    git:
+      url: https://github.com/Stausssi/network_tools
+      path: network_tools
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   convex_bottom_bar: ^3.0.0
   introduction_screen: ^3.0.2
   pull_to_refresh: ^2.0.0
-  google_mlkit_face_detection: ^0.4.0
+  google_mlkit_face_detection: ^0.3.0
   camera: ^0.10.0
   image: ^3.2.0
   dart_ping_ios: ^2.0.0


### PR DESCRIPTION
The bug caused an OSError to be thrown while searching for the mirror on the local network because iOS only allows 250 file handles but 255 where checked simultaneously. The error was thrown in the `network_tools` package and therefore had to be fixed in their code (which i did for them :)).

Fixes issue #7 